### PR TITLE
Build debian-based Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:8.12.0-stretch
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run: yarn install
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules
+      - run: yarn build
+      - run: echo "Sound! Euphonium"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Gatsby on Firebase Hosting
 
+[![CircleCI](https://circleci.com/gh/cheezenaan-sandbox/gatsby-firebase.svg?style=svg)](https://circleci.com/gh/cheezenaan-sandbox/gatsby-firebase)
+
 ## Introduction
 
 ```/bin/sh

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,30 +1,16 @@
-FROM alpine:3.8 as entrykit
+FROM buildpack-deps:stretch-curl as entrykit
 
 # Install Entrykit
 ENV ENTRYKIT_VERSION="0.4.0"
 RUN wget https://github.com/progrium/entrykit/releases/download/v${ENTRYKIT_VERSION}/entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz && \
   tar -xvzf entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz
 
-FROM node:8.12.0-alpine as dev
+FROM node:8.12.0-stretch as dev
 LABEL MAINTAINER "cheezenaan <cheezenaan@gmail.com>"
 
 ENV \
   APP_ROOT="/app" \
   LANG="C.UTF-8"
-
-RUN \
-  # dependencies for sharp
-  # ref. https://github.com/aripalo/gatsby-docker/blob/master/Dockerfile#L5-L9
-  apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing \
-  vips-tools \
-  vips-dev \
-  fftw-dev \
-  gcc \
-  g++ \
-  make \
-  libc6-compat && \
-  apk add --no-cache python && \
-  rm -rf /var/cache/apk/*
 
 WORKDIR $APP_ROOT
 


### PR DESCRIPTION
Circle CI の公式ベースイメージが ubuntu(debian)だったのでいっそのこと開発環境の Docker イメージも Alpine から debian に移行する。ついでに最低限の Circle CI の設定も追加しておく。

ref. 

- https://circleci.com/docs/2.0/circleci-images/
- https://circleci.com/docs/2.0/language-javascript/